### PR TITLE
Adjustment for ESLint 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ module.exports = {
     configs: {
         recommended: {
             rules: {
-                'marionette/deprecated-marionette-composite-view': 1,
-                'marionette/no-config-requiring': 0,
-                'marionette/no-left-out-listeners': 1,
-                'marionette/no-view-onoff-binding': 1,
-                'marionette/require-guard-in-subapps-only': 0,
-                'marionette/when-guard-in-controller-only': 0,
-                'marionette/no-translate-in-defaults': 0
+                '@silesia-corporation/marionette/deprecated-marionette-composite-view': 1,
+                '@silesia-corporation/marionette/no-config-requiring': 0,
+                '@silesia-corporation/marionette/no-left-out-listeners': 1,
+                '@silesia-corporation/marionette/no-view-onoff-binding': 1,
+                '@silesia-corporation/marionette/require-guard-in-subapps-only': 0,
+                '@silesia-corporation/marionette/when-guard-in-controller-only': 0,
+                '@silesia-corporation/marionette/no-translate-in-defaults': 0
             }
         }
     }

--- a/test/rules/no-translate-in-defaults.js
+++ b/test/rules/no-translate-in-defaults.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import rule from '../../lib/rules/translate-in-defaults-forbidden';
+import rule from '../../lib/rules/no-translate-in-defaults';
 import AvaRuleTester from 'eslint-ava-rule-tester';
 
 const ruleTester = new AvaRuleTester(test, {


### PR DESCRIPTION
Per http://eslint.org/docs/user-guide/migrating-to-4.0.0#scoped-plugin-resolution references to rules require to include the scope.